### PR TITLE
Adding numba compilation options

### DIFF
--- a/convst/__init__.py
+++ b/convst/__init__.py
@@ -1,5 +1,10 @@
 
 __author__ = 'Antoine Guillaume antoine.guillaume45@gmail.com'
-__version__ = "0.2.5"
+__version__ = "0.2.6"
 
 __all__ = ['transformers', 'classifiers', 'utils', 'interpreters']
+
+__USE_NUMBA_CACHE__ = True
+__USE_NUMBA_FASTMATH__ = True
+__USE_NUMBA_NOGIL__ = True
+__USE_NUMBA_PARALLEL__ = True

--- a/convst/transformers/_multivariate_same_length.py
+++ b/convst/transformers/_multivariate_same_length.py
@@ -17,7 +17,13 @@ from convst.transformers._commons import (
 
 from numba import njit, prange
 
-@njit(cache=True, nogil=True)
+from convst import (
+    __USE_NUMBA_CACHE__, __USE_NUMBA_FASTMATH__,
+    __USE_NUMBA_NOGIL__, __USE_NUMBA_PARALLEL__
+)
+
+
+@njit(cache=__USE_NUMBA_CACHE__, nogil=__USE_NUMBA_NOGIL__)
 def M_SL_init_random_shapelet_params(
     n_shapelets, shapelet_sizes, n_timestamps, p_norm, max_channels, prime_scheme
 ):
@@ -96,7 +102,7 @@ def M_SL_init_random_shapelet_params(
 
     return values, lengths, dilations, threshold, normalize, n_channels, channel_ids
 
-@njit(cache=True, parallel=True, nogil=True)
+@njit(cache=__USE_NUMBA_CACHE__, parallel=__USE_NUMBA_PARALLEL__, nogil=__USE_NUMBA_NOGIL__)
 def M_SL_generate_shapelet(
     X, y, n_shapelets, shapelet_sizes, r_seed, p_norm, p_min, p_max, alpha,
     dist_func, use_phase, max_channels, prime_scheme
@@ -273,7 +279,7 @@ def M_SL_generate_shapelet(
         channel_ids[:a2]
     )
 
-@njit(cache=True, parallel=True, fastmath=True, nogil=True)
+@njit(cache=__USE_NUMBA_CACHE__, parallel=__USE_NUMBA_PARALLEL__, fastmath=__USE_NUMBA_FASTMATH__, nogil=__USE_NUMBA_NOGIL__)
 def M_SL_apply_all_shapelets(
     X, shapelets, dist_func, use_phase
 ):

--- a/convst/transformers/_multivariate_variable_length.py
+++ b/convst/transformers/_multivariate_variable_length.py
@@ -17,7 +17,13 @@ from convst.transformers._commons import (
 
 from numba import njit, prange
 
-@njit(cache=True, nogil=True)
+from convst import (
+    __USE_NUMBA_CACHE__, __USE_NUMBA_FASTMATH__,
+    __USE_NUMBA_NOGIL__, __USE_NUMBA_PARALLEL__
+)
+
+
+@njit(cache=__USE_NUMBA_CACHE__, nogil=__USE_NUMBA_NOGIL__)
 def M_VL_init_random_shapelet_params(
     n_shapelets, shapelet_sizes, n_timestamps, p_norm, max_channels, prime_scheme
 ):
@@ -96,7 +102,7 @@ def M_VL_init_random_shapelet_params(
 
     return values, lengths, dilations, threshold, normalize, n_channels, channel_ids
 
-@njit(cache=True, parallel=True, nogil=True)
+@njit(cache=__USE_NUMBA_CACHE__, parallel=__USE_NUMBA_PARALLEL__, nogil=__USE_NUMBA_NOGIL__)
 def M_VL_generate_shapelet(
     X, y, n_shapelets, shapelet_sizes, r_seed, p_norm, p_min, p_max, alpha,
     dist_func, use_phase, max_channels, min_len, X_len, prime_scheme
@@ -302,7 +308,7 @@ def M_VL_generate_shapelet(
         channel_ids[:a2]
     )
 
-@njit(cache=True, parallel=True, fastmath=True, nogil=True)
+@njit(cache=__USE_NUMBA_CACHE__, parallel=__USE_NUMBA_PARALLEL__, fastmath=__USE_NUMBA_FASTMATH__, nogil=__USE_NUMBA_NOGIL__)
 def M_VL_apply_all_shapelets(
     X, shapelets, dist_func, use_phase, X_len
 ):

--- a/convst/transformers/_univariate_same_length.py
+++ b/convst/transformers/_univariate_same_length.py
@@ -16,7 +16,12 @@ from convst.transformers._commons import (
 
 from numba import njit, prange
 
-@njit(cache=True, nogil=True)
+from convst import (
+    __USE_NUMBA_CACHE__, __USE_NUMBA_FASTMATH__,
+    __USE_NUMBA_NOGIL__, __USE_NUMBA_PARALLEL__
+)
+
+@njit(cache=__USE_NUMBA_CACHE__, nogil=__USE_NUMBA_NOGIL__)
 def U_SL_init_random_shapelet_params(
     n_shapelets, shapelet_sizes, n_timestamps, p_norm, prime_scheme
 ):
@@ -81,7 +86,7 @@ def U_SL_init_random_shapelet_params(
 
     return values, lengths, dilations, threshold, normalize
 
-@njit(cache=True, parallel=True, nogil=True)
+@njit(cache=__USE_NUMBA_CACHE__, parallel=__USE_NUMBA_PARALLEL__, nogil=__USE_NUMBA_NOGIL__)
 def U_SL_generate_shapelet(
     X, y, n_shapelets, shapelet_sizes, r_seed, p_norm, p_min, p_max, alpha,
     dist_func, use_phase, prime_scheme
@@ -227,7 +232,7 @@ def U_SL_generate_shapelet(
     )
 
 
-@njit(cache=True, parallel=True, fastmath=True, nogil=True)
+@njit(cache=__USE_NUMBA_CACHE__, parallel=__USE_NUMBA_PARALLEL__, fastmath=__USE_NUMBA_FASTMATH__, nogil=__USE_NUMBA_NOGIL__)
 def U_SL_apply_all_shapelets(
     X, shapelets, dist_func, use_phase
 ):

--- a/convst/transformers/_univariate_variable_length.py
+++ b/convst/transformers/_univariate_variable_length.py
@@ -17,9 +17,12 @@ from convst.transformers._commons import (
 
 from numba import njit, prange
 
-# TODO : check if numba could support Tuple of variable length numpy arrays as input
+from convst import (
+    __USE_NUMBA_CACHE__, __USE_NUMBA_FASTMATH__,
+    __USE_NUMBA_NOGIL__, __USE_NUMBA_PARALLEL__
+)
 
-@njit(cache=True, nogil=True)
+@njit(cache=__USE_NUMBA_CACHE__, nogil=__USE_NUMBA_NOGIL__)
 def U_VL_init_random_shapelet_params(
     n_shapelets, shapelet_sizes, n_timestamps, p_norm, prime_scheme
 ):
@@ -87,7 +90,7 @@ def U_VL_init_random_shapelet_params(
     return values, lengths, dilations, threshold, normalize
 
 
-@njit(cache=True, parallel=True, nogil=True)
+@njit(cache=__USE_NUMBA_CACHE__, parallel=__USE_NUMBA_PARALLEL__, nogil=__USE_NUMBA_NOGIL__)
 def U_VL_generate_shapelet(
     X, y, n_shapelets, shapelet_sizes, r_seed, p_norm, p_min, p_max, alpha,
     dist_func, use_phase, min_len, X_len, prime_scheme
@@ -259,7 +262,7 @@ def U_VL_generate_shapelet(
     )
 
 
-@njit(cache=True, parallel=True, fastmath=True, nogil=True)
+@njit(cache=__USE_NUMBA_CACHE__, parallel=__USE_NUMBA_PARALLEL__, fastmath=__USE_NUMBA_FASTMATH__, nogil=__USE_NUMBA_NOGIL__)
 def U_VL_apply_all_shapelets(
     X, shapelets, dist_func, use_phase, X_len
 ):

--- a/examples/Changing_numba_options.py
+++ b/examples/Changing_numba_options.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+
+"""
+Example of changing numba configuration for RDST
+================================================
+
+This example shows how to modify the numba options to change the behaviour of 
+numba functions
+"""
+# %%
+# Load the module and change the numba options
+# --------------------------------------------
+#
+# The __init__.py file of convst contains four variable that will change how 
+# numba functions are compiled, please refer to the numba documentation for
+# the effect of each option. In a classic desktop use of convst, you should
+# not need to change any option. Issue have been known to occur on some HPC
+# cluster. By default, the variables are all defined as True, here we change
+# the value of __USE_NUMBA_CACHE__ and __USE_NUMBA_PARALLEL__ to False.
+
+import convst
+
+convst.__USE_NUMBA_CACHE__= False
+convst.__USE_NUMBA_FASTMATH__ = True
+convst.__USE_NUMBA_NOGIL__ = True
+convst.__USE_NUMBA_PARALLEL__ = False
+
+# %%
+# Run convst with the modified numba options
+# ------------------------------------------
+#
+# We can now use convst with these options, to check if the changes have been
+# taken into account, we can inspect a numba function argument.
+# !! THE MODIFICATION OF THE NUMBA CONFIGURATION MUST BE MADE BEFORE CALLING
+# ANY NUMBA FUNCTION, NUMBA TREAT GLOBAL VARIABLE AT CONSTANT AT COMPILE TIME
+# CHANGING THE VALUE OF THESE PARAMETER AFTER A FUNCTION IS COMPILED WILL NOT
+# CHANGE ITS BEHAVIOR.
+
+from convst.transformers._univariate_same_length import U_SL_apply_all_shapelets
+print(U_SL_apply_all_shapelets.targetoptions)

--- a/examples/UCR_example.py
+++ b/examples/UCR_example.py
@@ -20,7 +20,7 @@ from convst.utils.dataset_utils import load_sktime_dataset_split
 
 X_train, X_test, y_train, y_test, _ = load_sktime_dataset_split('GunPoint')
 
-rdst = R_DST_Ridge(n_shapelets=10000, n_jobs=-1)
+rdst = R_DST_Ridge(n_shapelets=10000, n_jobs=1)
 
 rdst.fit(X_train, y_train)
 acc_score = rdst.score(X_test, y_test)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "convst"
 
-version = "0.2.5"
+version = "0.2.6"
 
 description = "The Random Dilation Shapelet Transform algorithm and associated works"
 readme = "README.md"


### PR DESCRIPTION
Adding variables to modify numba compilation options, these must be set before compilation time. See the new example file `Changing_numba_options.py` to learn how to modify them.